### PR TITLE
 Add worker API for dealing with spawning/termination of routines

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -135,6 +135,10 @@ rec {
             packageId = "futures";
           }
           {
+            name = "lazy_static";
+            packageId = "lazy_static";
+          }
+          {
             name = "tokio";
             packageId = "tokio";
             features = [ "rt-core" "sync" "macros" "time" ];
@@ -521,6 +525,18 @@ rec {
           "write-all-vectored" = [ "io" ];
         };
         resolvedDefaultFeatures = [ "alloc" "async-await" "async-await-macro" "channel" "futures-channel" "futures-io" "futures-macro" "futures-sink" "io" "memchr" "proc-macro-hack" "proc-macro-nested" "sink" "slab" "std" ];
+      };
+      "lazy_static" = rec {
+        crateName = "lazy_static";
+        version = "1.4.0";
+        edition = "2015";
+        sha256 = "0in6ikhw8mgl33wjv6q6xfrb5b9jr16q8ygjy803fay4zcisvaz2";
+        authors = [
+          "Marvin Löbel <loebel.marvin@gmail.com>"
+        ];
+        features = {
+          "spin_no_std" = [ "spin" ];
+        };
       };
       "libc" = rec {
         crateName = "libc";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2018"
 [dependencies]
 anyhow      = { version = "1.0.31" }
 chrono      = { version = "0.4.13" }
-lazy_static = { version = "1.4.0" }
 futures     = { version = "0.3.5"  }
+lazy_static = { version = "1.4.0" }
 tokio       = { version = "0.2.22", features = ["rt-core", "sync", "macros", "time"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow  = { version = "1.0.31" }
-chrono  = { version = "0.4.13" }
-futures = { version = "0.3.5"  }
-tokio   = { version = "0.2.22", features = ["rt-core", "sync", "macros", "time"] }
+anyhow      = { version = "1.0.31" }
+chrono      = { version = "0.4.13" }
+lazy_static = { version = "1.4.0" }
+futures     = { version = "0.3.5"  }
+tokio       = { version = "0.2.22", features = ["rt-core", "sync", "macros", "time"] }
 
 [dev-dependencies]
-tokio = { version = "0.2.22", features = ["test-util"] }
+tokio      = { version = "0.2.22", features = ["test-util"] }
 tokio-test = { version = "0.2.1" }

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ help:	## Display this message
 .PHONY: help
 .DEFAULT_GOAL := help
 
+Cargo.nix: Cargo.toml
+	crate2nix generate -n ./nix/packages.nix
+
 test: ## Run tests
 	cargo test
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ help:	## Display this message
 Cargo.nix: Cargo.toml
 	crate2nix generate -n ./nix/packages.nix
 
-test: ## Run tests
+test: Cargo.nix ## Run tests
 	cargo test
 .PHONY: test
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 // I dislike Default trait, like... a lot
 #[allow(clippy::new_without_default)]
+mod context;
+mod worker;
 
-pub mod context;
+pub use context::Context;
+pub use worker::{Restart, Shutdown, StartNotifier};
+
+pub type Worker = worker::Spec;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate lazy_static;
+
 // I dislike Default trait, like... a lot
 #[allow(clippy::new_without_default)]
 mod context;

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,0 +1,320 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use futures::future::{AbortHandle, Abortable, Aborted, BoxFuture, Future, FutureExt};
+use tokio::sync::oneshot;
+use tokio::task::{self, JoinHandle};
+use tokio::time;
+
+use crate::context::Context;
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum Restart {
+    Permanent,
+    Transient,
+    Temporary,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Shutdown {
+    Indefinitely,
+    Timeout(Duration),
+}
+
+/// StartNotifier offers a convenient way to notify a worker spawner (a
+/// Supervisor in the general case) that the worker got started (or failed) to
+/// start.
+pub struct StartNotifier(Box<dyn FnOnce(Option<anyhow::Error>) + Send>);
+
+impl StartNotifier {
+    pub fn from_oneshot(sender: oneshot::Sender<Option<anyhow::Error>>) -> Self {
+        StartNotifier(Box::new(move |err| {
+            let _ = sender.send(err);
+        }))
+    }
+
+    fn call(self, err: Option<anyhow::Error>) {
+        self.0(err)
+    }
+
+    pub fn success(self) {
+        self.call(None)
+    }
+
+    pub fn failed(self, err: anyhow::Error) {
+        self.call(Some(err))
+    }
+}
+
+pub struct Spec {
+    name: String,
+    restart: Restart,
+    shutdown: Shutdown,
+    routine:
+        Box<dyn FnMut(Context, StartNotifier) -> BoxFuture<'static, Result<(), anyhow::Error>>>,
+}
+
+/// Worker represents an routine that got started from a worker::Spec.
+/// It contains metadata and also offers an API to provide graceful and
+/// forceful termination
+pub struct Worker {
+    spec: Spec,
+    runtime_name: String,
+    created_at: DateTime<Utc>,
+    join_handle: JoinHandle<Result<anyhow::Result<()>, Aborted>>,
+    termination_handle: AbortHandle,
+    kill_handle: AbortHandle,
+}
+
+impl Spec {
+    /// new creates a worker routine. It requires two arguments: a name that is
+    /// used for runtime tracing and a start function that returns a routine
+    /// that is going to be executed in a Future task concurrently.
+    ///
+    /// ### The name argument
+    ///
+    /// A name argument must not be empty nor contain forward slash characters
+    ///
+    /// ### The start function
+    ///
+    /// This function is where your business logic should be located. it will be
+    /// running on a new supervised routine.
+    ///
+    /// The start function will receive a Context record that **must** be used
+    /// inside your business logic to accept stop signals from the supervisor
+    /// that manages this routine life-cycle.
+    pub fn new<F, O>(name: &str, mut routine0: F) -> Self
+    where
+        F: FnMut(Context) -> O + 'static,
+        O: Future<Output = anyhow::Result<()>> + FutureExt + Send + Sized + 'static,
+    {
+        let routine1 = move |ctx: Context, on_start: StartNotifier| {
+            on_start.call(None);
+            routine0(ctx).boxed()
+        };
+        Spec {
+            name: name.to_owned(),
+            shutdown: Shutdown::Indefinitely,
+            restart: Restart::Permanent,
+            routine: Box::new(routine1),
+        }
+    }
+
+    /// new_with_start accomplishes the same goal as new with the addition of
+    /// passing an extra argument to the start function, a StartNotifier record.
+    ///
+    /// ### The StartNotifier argument in the start function
+    ///
+    /// Sometimes you want to consider a routine started after certain
+    /// initialization is done; like doing a read from a Database or API, or
+    /// when some socket is bound, etc. The StartNotifier allows the spawned
+    /// worker routine to signal when it has initialized.
+    ///
+    /// It is essential to call the API from the StartNotifier function in your
+    /// business logic as soon as you consider the worker is initialized,
+    /// otherwise the parent supervisor will block and eventually fail with a
+    /// timeout.
+    ///
+    /// ### Report a start error with the StartNotifier
+    ///
+    /// If for some reason, a worker is not able to start correctly (e.g. DB
+    /// connection fails, network is kaput, etc.), the worker may call the
+    /// `StartNotifier#failed` function with the impending error as a parameter.
+    /// This will cause the whole supervision system start procedure to abort
+    /// and fail fast.
+    ///
+    pub fn new_with_start<F, O>(name: &str, mut routine0: F) -> Self
+    where
+        F: FnMut(Context, StartNotifier) -> O + 'static,
+        O: Future<Output = anyhow::Result<()>> + FutureExt + Send + Sized + 'static,
+    {
+        let routine1 = move |ctx: Context, on_start: StartNotifier| routine0(ctx, on_start).boxed();
+        Spec {
+            name: name.to_owned(),
+            shutdown: Shutdown::Indefinitely,
+            restart: Restart::Permanent,
+            routine: Box::new(routine1),
+        }
+    }
+
+    /// restart is a builder method that allows to modify the Restart settings
+    /// for the spawned worker
+    pub fn restart(mut self, restart: Restart) -> Self {
+        self.restart = restart;
+        self
+    }
+
+    /// shutdown is a builder method that allows to modify the Restart settings
+    /// for the spawned worker
+    pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
+        self.shutdown = shutdown;
+        self
+    }
+
+    /// start spawns a new routine that executes the start function of this
+    /// Spec.
+    ///
+    /// ### Blocking on start function
+    ///
+    /// This function will block and wait until a notification from the
+    /// start function (executing on a newly spawned routine) is received; this
+    /// notification indicates if the start was successful or not.
+    ///
+    /// This blocking is necessary to ensure that supervised worker trees get
+    /// spawned in the specified/expected order.
+    pub async fn start(
+        mut self,
+        parent_ctx: &Context,
+        parent_name: &str,
+    ) -> anyhow::Result<Worker> {
+        let runtime_name = format!("{}/{}", parent_name, self.name);
+        let created_at = Utc::now();
+
+        // ON_START setup
+        let (started_tx, started_rx) = oneshot::channel::<Option<anyhow::Error>>();
+        let start_notifier = StartNotifier::from_oneshot(started_tx);
+
+        // CANCEL setup
+        let (ctx, termination_handle) = Context::with_cancel(parent_ctx);
+        let (kill_handle, kill_registration) = AbortHandle::new_pair();
+        let future = (*self.routine)(ctx, start_notifier);
+        let routine = Abortable::new(future, kill_registration);
+
+        // SPAWN -- actually spawn concurrent worker future
+        let join_handle = task::spawn(routine);
+
+        // ON_START blocking -- block before moving to the next start
+        let err = started_rx.await;
+
+        match err {
+            // On worker initialization failed, we need to signal
+            // this to starter
+            Err(err) => Err(anyhow::Error::new(err)),
+            Ok(Some(err)) => Err(err),
+
+            // Happy path
+            Ok(None) => Ok(Worker {
+                spec: self,
+                runtime_name,
+                created_at,
+                join_handle,
+                termination_handle,
+                kill_handle,
+            }),
+        }
+    }
+}
+
+impl Worker {
+    /// terminate tries to stop gracefuly a worker routine. In the scenario that
+    /// the routine doesn't stop after a timeout, it is brutally killed.
+    pub async fn terminate(self) -> Result<Spec, Arc<anyhow::Error>> {
+        self.termination_handle.abort();
+
+        let mut delay = time::delay_for(Duration::from_millis(1000));
+        tokio::select! {
+           _ = &mut delay => {
+               self.termination_handle.abort();
+               return Ok(self.spec)
+           },
+           result = self.join_handle => {
+               match result {
+                   Ok(Ok(_)) => return Ok(self.spec),
+                   Ok(Err(_future_err)) => {
+                       // TODO:
+                       // * deal with termination error
+                       return Ok(self.spec);
+                   },
+                   Err(_abort_err) => {
+                       // TODO:
+                       // * deal with abort error
+                       return Ok(self.spec);
+                   },
+               }
+           }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use tokio::sync::mpsc;
+
+    use crate::context::*;
+    use crate::worker::{self, StartNotifier};
+
+    fn start_err_worker(name: &str, err_msg: &'static str) -> worker::Spec {
+        worker::Spec::new_with_start(name, move |_: Context, start: StartNotifier| async move {
+            start.failed(anyhow::Error::msg(err_msg.to_owned()));
+            Ok(())
+        })
+    }
+
+    #[tokio::test]
+    async fn test_worker_simple_start() {
+        let (before_tx, mut before_rx) = mpsc::channel(1);
+        let (after_tx, mut after_rx) = mpsc::channel(1);
+
+        let routine = move |ctx: Context| {
+            let mut before_tx = before_tx.clone();
+            let mut after_tx = after_tx.clone();
+            async move {
+                // wait for worker to be done
+                let _ = before_tx.send(()).await;
+                ctx.done.await;
+                let _ = after_tx.send(()).await;
+                Ok(())
+            }
+        };
+
+        let spec = worker::Spec::new("child1", routine);
+
+        let ctx = Context::new();
+        let start_result = spec.start(&ctx, "root").await;
+        let worker = start_result.expect("successful worker creation");
+
+        before_rx.recv().await;
+        let stop_result = worker.terminate().await;
+        let _ = stop_result.expect("successful worker termination");
+        after_rx.recv().await;
+    }
+
+    #[tokio::test]
+    async fn test_worker_start_success() {
+        let (after_tx, mut after_rx) = mpsc::channel(1);
+
+        let routine = move |ctx: Context, start: StartNotifier| {
+            let mut after_tx = after_tx.clone();
+            async move {
+                // wait for worker to be done
+                start.success();
+                ctx.done.await;
+                let _ = after_tx.send(()).await;
+                Ok(())
+            }
+        };
+
+        let spec = worker::Spec::new_with_start("child1", routine);
+
+        let ctx = Context::new();
+        let result = spec.start(&ctx, "root").await;
+        let worker = result.expect("expecting successful worker creation");
+
+        let _ = worker.terminate().await;
+        after_rx.recv().await;
+    }
+
+    #[tokio::test]
+    async fn test_worker_start_failure() {
+        let spec = start_err_worker("child1", "boom");
+
+        let ctx = Context::new();
+        let result = spec.start(&ctx, "root").await;
+        match result {
+            Err(start_err1) => assert_eq!("boom", format!("{:?}", start_err1)),
+            Ok(_) => panic!("expecting error, got result"),
+        }
+    }
+}

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -241,7 +241,7 @@ impl Worker {
         let result = time::timeout(self.spec.termination_timeout, self.join_handle).await;
         match result {
             Err(termination_timeout_err) => {
-                self.termination_handle.abort();
+                self.kill_handle.abort();
                 (
                     self.spec,
                     Some(Arc::new(anyhow::Error::new(termination_timeout_err))),

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -386,6 +386,8 @@ mod tests {
 
         match result {
             Err(start_timeout_err) => {
+                // TODO: create well-defined capataz error that describes the error
+                // succintly
                 assert_eq!("deadline has elapsed", format!("{:?}", start_timeout_err))
             }
             Ok(_) => panic!("expecting error, got result"),
@@ -401,9 +403,16 @@ mod tests {
 
         match result {
             Err(start_not_called_err) => {
+                // TODO: create well-defined capataz error that describes the error
+                // succintly
                 assert_eq!("channel closed", format!("{:?}", start_not_called_err))
             }
             Ok(_) => panic!("expecting error, got result"),
         }
     }
+
+    // TODO: Termination tests
+    // * termination success
+    // * termination error
+    // * termination time out
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -276,7 +276,7 @@ mod tests {
     fn start_err_worker(name: &str, err_msg: &'static str) -> worker::Spec {
         worker::Spec::new_with_start(name, move |_: Context, start: StartNotifier| async move {
             start.failed(anyhow::Error::msg(err_msg.to_owned()));
-            Ok(())
+            Err(anyhow::Error::msg("should not see this"))
         })
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -9,6 +9,7 @@ use tokio::time;
 
 use crate::context::Context;
 
+// TODO: replace with OnceCell
 lazy_static! {
     static ref WORKER_START_TIMEOUT: Duration = Duration::from_secs(1);
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -33,7 +33,7 @@ pub enum Shutdown {
 pub struct StartNotifier(Box<dyn FnOnce(Result<(), anyhow::Error>) + Send>);
 
 impl StartNotifier {
-    pub fn from_oneshot(sender: oneshot::Sender<Result<(), anyhow::Error>>) -> Self {
+    fn from_oneshot(sender: oneshot::Sender<Result<(), anyhow::Error>>) -> Self {
         StartNotifier(Box::new(move |err| {
             let _ = sender.send(err);
         }))

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -9,6 +9,11 @@ use tokio::time;
 
 use crate::context::Context;
 
+lazy_static! {
+    static ref WORKER_START_TIMEOUT: Duration = Duration::from_secs(1);
+    static ref WORKER_TERMINATION_TIMEOUT: Duration = Duration::from_secs(1);
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Restart {
     Permanent,
@@ -49,6 +54,8 @@ impl StartNotifier {
 
 pub struct Spec {
     name: String,
+    start_timeout: Duration,
+    termination_timeout: Duration,
     restart: Restart,
     shutdown: Shutdown,
     routine:
@@ -95,6 +102,8 @@ impl Spec {
         };
         Spec {
             name: name.to_owned(),
+            start_timeout: *WORKER_START_TIMEOUT,
+            termination_timeout: *WORKER_TERMINATION_TIMEOUT,
             shutdown: Shutdown::Indefinitely,
             restart: Restart::Permanent,
             routine: Box::new(routine1),
@@ -132,6 +141,8 @@ impl Spec {
         let routine1 = move |ctx: Context, on_start: StartNotifier| routine0(ctx, on_start).boxed();
         Spec {
             name: name.to_owned(),
+            start_timeout: *WORKER_START_TIMEOUT,
+            termination_timeout: *WORKER_TERMINATION_TIMEOUT,
             shutdown: Shutdown::Indefinitely,
             restart: Restart::Permanent,
             routine: Box::new(routine1),
@@ -149,6 +160,16 @@ impl Spec {
     /// for the spawned worker
     pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
         self.shutdown = shutdown;
+        self
+    }
+
+    pub fn start_timeout(mut self, timeout: Duration) -> Self {
+        self.start_timeout = timeout;
+        self
+    }
+
+    pub fn termination_timeout(mut self, timeout: Duration) -> Self {
+        self.termination_timeout = timeout;
         self
     }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -145,7 +145,7 @@ impl Spec {
         self
     }
 
-    /// shutdown is a builder method that allows to modify the Restart settings
+    /// shutdown is a builder method that allows to modify the Shutdown settings
     /// for the spawned worker
     pub fn shutdown(mut self, shutdown: Shutdown) -> Self {
         self.shutdown = shutdown;


### PR DESCRIPTION
## Problem: 

I need a way to have an internal, easy to use API to manage spawning and termination of routines that are intended to be supervised by a Supervisor.

## Solution:

Implement a worker module that offers an API to create a `Spec` and a `Worker` (e.g. runtime representation that is going to be managed by a future `Supervisor` type).

## Acceptance Criteria

* [x] Easy way to configure a worker using builder pattern
* [x] Offer a way to start worker routine and wait until the worker routine is done
* [x] API is tested 