### PR TITLE
Add unit tests for worker termination logic

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -139,6 +139,10 @@ rec {
             packageId = "lazy_static";
           }
           {
+            name = "thiserror";
+            packageId = "thiserror";
+          }
+          {
             name = "tokio";
             packageId = "tokio";
             features = [ "rt-core" "sync" "macros" "time" ];
@@ -793,6 +797,47 @@ rec {
           "test" = [ "syn-test-suite/all-features" ];
         };
         resolvedDefaultFeatures = [ "clone-impls" "default" "derive" "full" "parsing" "printing" "proc-macro" "quote" "visit-mut" ];
+      };
+      "thiserror" = rec {
+        crateName = "thiserror";
+        version = "1.0.20";
+        edition = "2018";
+        sha256 = "020d7pfq7vg2iw1bbilnyq764zy35ncg2syn9a7vgk6qriqd1zbx";
+        authors = [
+          "David Tolnay <dtolnay@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "thiserror-impl";
+            packageId = "thiserror-impl";
+          }
+        ];
+        
+      };
+      "thiserror-impl" = rec {
+        crateName = "thiserror-impl";
+        version = "1.0.20";
+        edition = "2018";
+        sha256 = "14qphjwa68sfjk3404iwv6hh8kvk6vmcwan9589sqqrhyw9gr05x";
+        procMacro = true;
+        authors = [
+          "David Tolnay <dtolnay@gmail.com>"
+        ];
+        dependencies = [
+          {
+            name = "proc-macro2";
+            packageId = "proc-macro2";
+          }
+          {
+            name = "quote";
+            packageId = "quote";
+          }
+          {
+            name = "syn";
+            packageId = "syn";
+          }
+        ];
+        
       };
       "time" = rec {
         crateName = "time";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2018"
 anyhow      = { version = "1.0.31" }
 chrono      = { version = "0.4.13" }
 futures     = { version = "0.3.5"  }
-lazy_static = { version = "1.4.0" }
+lazy_static = { version = "1.4.0"  }
+thiserror   = { version = "1.0.20" }
 tokio       = { version = "0.2.22", features = ["rt-core", "sync", "macros", "time"] }
 
 [dev-dependencies]

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -522,6 +522,9 @@ mod tests {
                     "deadline has elapsed",
                     format!("{:?}", termination_timeout_err)
                 );
+                // NOTE: not sure how to validate the abort logic got executed,
+                // and what the side-effects of those are. @RadicalZephyr, if
+                // you have any ideas, I'm all ears.
             }
             None => panic!("expecting error, got none"),
         }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -223,6 +223,7 @@ impl Spec {
         mut self,
         parent_ctx: &Context,
         parent_name: &str,
+        // TODO: pending parent channel to notify errors that happened
     ) -> anyhow::Result<Worker> {
         let runtime_name = format!("{}/{}", parent_name, self.name);
         let created_at = Utc::now();
@@ -237,6 +238,10 @@ impl Spec {
         let future = (*self.routine)(ctx, start_notifier);
         let routine = Abortable::new(future, kill_registration);
 
+        // TODO: decorate routine to wait for client routine result, and
+
+        // if it is an error, send the error to the supervisor through
+        // the given channel
         // SPAWN -- actually spawn concurrent worker future
         let join_handle = task::spawn(routine);
 
@@ -516,9 +521,6 @@ mod tests {
         let ctx = Context::new();
         let worker = spec.start(&ctx, "root").await.expect("should match worker");
 
-        // QUESTION/TODO: I've some doubts here, what would happen if a future
-        // panics and we don't do an await on it? How can we verify worker futures
-        // are running with no panics without calling .await on them?
         let (_, result) = worker.terminate().await;
 
         match result {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use futures::future::{AbortHandle, Abortable, Aborted, BoxFuture, Future, FutureExt};
+use futures::future::{abortable, AbortHandle, Aborted, BoxFuture, Future, FutureExt};
+use thiserror::Error;
 use tokio::sync::oneshot;
 use tokio::task::{self, JoinError, JoinHandle};
 use tokio::time;
@@ -33,43 +33,114 @@ pub enum Shutdown {
     Timeout(Duration),
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum TerminationError {
-    TimeoutError(time::Elapsed),
-    CancelError(JoinError),
-    PanicError(JoinError),
-    KillError(Aborted),
-    ClientError(anyhow::Error),
+    #[error("worker routine termination timeout")]
+    TimeoutError {
+        #[from]
+        source: time::Elapsed,
+    },
+    #[error("worker routine termination canceled or paniced")]
+    JoinHandleError {
+        #[from]
+        source: JoinError,
+    },
+    #[error("worker routine terminated by hard kill")]
+    KillError {
+        #[from]
+        source: Aborted,
+    },
+    #[error(transparent)]
+    WorkerError {
+        #[from]
+        source: anyhow::Error,
+    },
 }
 
-impl std::fmt::Display for TerminationError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use TerminationError::*;
+impl TerminationError {
+    fn is_timeout_error(&self) -> bool {
         match self {
-            TimeoutError(_) => write!(fmt, "worker routine termination timeout"),
-            CancelError(_) => write!(fmt, "worker routine canceled"),
-            PanicError(_) => write!(fmt, "worker routine terminated by panic"),
-            KillError(_) => write!(fmt, "worker routine terminated by hard kill"),
-            ClientError(_) => write!(fmt, "worker routine finished with error"),
+            TerminationError::TimeoutError { .. } => true,
+            _ => false,
+        }
+    }
+    fn is_join_handle_error(&self) -> bool {
+        match self {
+            TerminationError::JoinHandleError { .. } => true,
+            _ => false,
+        }
+    }
+
+    // TODO: need to find a decent way to setup an error scenario
+    // where this verification method is called
+    // fn is_kill_error(&self) -> bool {
+    //     match self {
+    //         TerminationError::KillError { .. } => true,
+    //         _ => false,
+    //     }
+    // }
+
+    pub fn is_worker_termination_error(&self) -> bool {
+        match self {
+            TerminationError::WorkerError { .. } => true,
+            _ => false,
         }
     }
 }
 
-impl std::error::Error for TerminationError {}
+#[derive(Error, Debug)]
+pub enum StartError {
+    #[error("worker routine start timeout")]
+    TimeoutError {
+        #[from]
+        source: time::Elapsed,
+    },
+    #[error("worker routine did not notify start")]
+    NotifyStartError {
+        #[from]
+        source: oneshot::error::RecvError,
+    },
+    #[error(transparent)]
+    InitError {
+        #[from]
+        source: anyhow::Error,
+    },
+}
+
+impl StartError {
+    fn is_timeout_error(&self) -> bool {
+        match self {
+            StartError::TimeoutError { .. } => true,
+            _ => false,
+        }
+    }
+    fn is_notify_start_error(&self) -> bool {
+        match self {
+            StartError::NotifyStartError { .. } => true,
+            _ => false,
+        }
+    }
+    pub fn is_worker_init_error(&self) -> bool {
+        match self {
+            StartError::InitError { .. } => true,
+            _ => false,
+        }
+    }
+}
 
 /// StartNotifier offers a convenient way to notify a worker spawner (a
 /// Supervisor in the general case) that the worker got started or that it
 /// failed to start.
-pub struct StartNotifier(Box<dyn FnOnce(Result<(), anyhow::Error>) + Send>);
+pub struct StartNotifier(Box<dyn FnOnce(Result<(), StartError>) + Send>);
 
 impl StartNotifier {
-    fn from_oneshot(sender: oneshot::Sender<Result<(), anyhow::Error>>) -> Self {
+    fn from_oneshot(sender: oneshot::Sender<Result<(), StartError>>) -> Self {
         StartNotifier(Box::new(move |err| {
             let _ = sender.send(err);
         }))
     }
 
-    fn call(self, err: Result<(), anyhow::Error>) {
+    fn call(self, err: Result<(), StartError>) {
         self.0(err)
     }
 
@@ -78,7 +149,7 @@ impl StartNotifier {
     }
 
     pub fn failed(self, err: anyhow::Error) {
-        self.call(Err(err))
+        self.call(Err(StartError::InitError { source: err }))
     }
 }
 
@@ -224,42 +295,59 @@ impl Spec {
         parent_ctx: &Context,
         parent_name: &str,
         // TODO: pending parent channel to notify errors that happened
-    ) -> anyhow::Result<Worker> {
+    ) -> Result<Worker, (Self, StartError)> {
         let runtime_name = format!("{}/{}", parent_name, self.name);
         let created_at = Utc::now();
 
         // ON_START setup
-        let (started_tx, started_rx) = oneshot::channel::<Result<(), anyhow::Error>>();
+        //
+        // START WRAPPER (A)
+        // StartNotifier wraps the original worker routine, of type Result<(), StartError>
+        // with a Result<ORIGINAL, RecvError>
+        let (started_tx, started_rx) = oneshot::channel::<Result<(), StartError>>();
         let start_notifier = StartNotifier::from_oneshot(started_tx);
 
         // CANCEL setup
         let (ctx, termination_handle) = Context::with_cancel(parent_ctx);
-        let (kill_handle, kill_registration) = AbortHandle::new_pair();
-        let future = (*self.routine)(ctx, start_notifier);
-        let routine = Abortable::new(future, kill_registration);
+        let worker_routine0 = (*self.routine)(ctx, start_notifier);
 
-        // TODO: decorate routine to wait for client routine result, and
+        // KILL setup
+        //
+        // TERMINATION WRAPPER (A)
+        // abortable wraps the original worker routine, of type Result<(), anyhow::Error>
+        // with a Result<ORIGINAL, Aborted>
+        let (worker_routine1, kill_handle) = abortable(worker_routine0);
 
-        // if it is an error, send the error to the supervisor through
-        // the given channel
+        // TODO: OBSERVE setup -- decorate routine to wait for client routine
+        // result, and if it is an error, send the error to the supervisor
+        // through the given channel
+
         // SPAWN -- actually spawn concurrent worker future
-        let join_handle = task::spawn(routine);
+        //
+        // TERMINATION WRAPPER (B)
+        // spawn wraps the original worker routine with a Result<ORIGINAL, JoinError>
+        let join_handle = task::spawn(worker_routine1);
 
         // ON_START blocking -- block before moving to the next start
-        let err = time::timeout(self.start_timeout, started_rx).await;
+        //
+        // START WRAPPER (B)
+        // timeout wraps the already decorated worker routine with a Result<WRAPPER (A), Timeout::Delay>
+        let result = time::timeout(
+            self.start_timeout,
+            started_rx, // START WRAPER (A)
+        )
+        .await;
 
-        match err {
-            // On worker initialization failed, we need to signal
-            // this to starter
-            Err(start_timeout_err) => Err(anyhow::Error::new(start_timeout_err)),
-
-            Ok(Err(start_notify_not_invoked_err)) => {
-                Err(anyhow::Error::new(start_notify_not_invoked_err))
-            }
-
-            Ok(Ok(Err(routine_err))) => Err(routine_err),
-
-            // Happy path
+        // The following match is nasty, but is inherent to the way we are decorating
+        // the original routine future provided by the API client.
+        match result {
+            // START WRAPER (B)
+            Err(start_timeout_err) => Err((self, From::from(start_timeout_err))),
+            // START WRAPER (A)
+            Ok(Err(start_sender_err)) => Err((self, From::from(start_sender_err))),
+            // ORIGINAL Init ERROR
+            Ok(Ok(Err(worker_init_err))) => Err((self, From::from(worker_init_err))),
+            // No Error registered, returning Worker
             Ok(Ok(Ok(_))) => Ok(Worker {
                 spec: self,
                 runtime_name,
@@ -275,11 +363,21 @@ impl Spec {
 impl Worker {
     /// terminate tries to stop gracefuly a worker routine. In the scenario that
     /// the routine doesn't stop after a timeout, it is brutally killed.
-    pub async fn terminate(self) -> (Spec, Option<Arc<TerminationError>>) {
+    pub async fn terminate(self) -> Result<Spec, (Spec, TerminationError)> {
+        // SIGNAL WORKER TERMINATION -- this call will cause the ctx.done future on the worker's
+        // select! call to signal a finish for cleanup
         self.termination_handle.abort();
 
+        // TERMINATION TIMEOUT --- we check the worker spec for a termination
+        // timeout, if there is one we do the waiting
+        //
+        // TERMINATION WRAPPER (C)
+        // timeout wraps the already decorated worker routine with a Result<WRAPPER (A), Timeout::Delay>
         let result = match self.spec.termination_timeout {
             TerminationTimeout::Infinity => {
+                // Given that the timeout wraps the result with Result<_, Timeout::Delay>,
+                // we need to wrap the original value with Ok so that the `match` brackets have
+                // the same type
                 let result = self.join_handle.await;
                 Ok(result)
             }
@@ -289,43 +387,19 @@ impl Worker {
         };
 
         match result {
+            // TERMINATION WRAPPER (C)
             Err(termination_timeout_err) => {
                 self.kill_handle.abort();
-                (
-                    self.spec,
-                    Some(Arc::new(TerminationError::TimeoutError(
-                        termination_timeout_err,
-                    ))),
-                )
+                Err((self.spec, From::from(termination_timeout_err)))
             }
-
-            //
-            Ok(Err(join_handle_err)) => {
-                if join_handle_err.is_panic() {
-                    (
-                        self.spec,
-                        Some(Arc::new(TerminationError::PanicError(join_handle_err))),
-                    )
-                } else {
-                    (
-                        self.spec,
-                        Some(Arc::new(TerminationError::CancelError(join_handle_err))),
-                    )
-                }
-            }
-
-            Ok(Ok(Err(kill_err))) => (
-                self.spec,
-                Some(Arc::new(TerminationError::KillError(kill_err))),
-            ),
-
-            Ok(Ok(Ok(Err(termination_err)))) => (
-                self.spec,
-                Some(Arc::new(TerminationError::ClientError(termination_err))),
-            ),
-
-            // happy path
-            Ok(Ok(Ok(Ok(_)))) => (self.spec, None),
+            // TERMINATION WRAPPER (B)
+            Ok(Err(join_handle_err)) => Err((self.spec, From::from(join_handle_err))),
+            // TERMINATION WRAPPER (A)
+            Ok(Ok(Err(kill_err))) => Err((self.spec, From::from(kill_err))),
+            // ORIGINAL ERROR (worker routine failed)
+            Ok(Ok(Ok(Err(worker_err)))) => Err((self.spec, From::from(worker_err))),
+            // Worker terminated without any hiccup
+            Ok(Ok(Ok(Ok(_)))) => Ok(self.spec),
         }
     }
 }
@@ -425,12 +499,15 @@ mod tests {
         let spec = worker::Spec::new("child1", routine);
 
         let ctx = Context::new();
-        let start_result = spec.start(&ctx, "root").await;
+        let start_result = spec.start(&ctx, "root").await.map_err(|err| err.1);
         let worker = start_result.expect("successful worker creation");
 
         before_rx.recv().await;
-        let (_spec, stop_err) = worker.terminate().await;
-        assert!(stop_err.is_none());
+        worker
+            .terminate()
+            .await
+            .map_err(|err| err.1)
+            .expect("worker termination must succeed");
         after_rx.recv().await;
     }
 
@@ -452,7 +529,7 @@ mod tests {
         let spec = worker::Spec::new_with_start("child1", routine);
 
         let ctx = Context::new();
-        let result = spec.start(&ctx, "root").await;
+        let result = spec.start(&ctx, "root").await.map_err(|err| err.1);
         let worker = result.expect("expecting successful worker creation");
 
         let _ = worker.terminate().await;
@@ -464,11 +541,13 @@ mod tests {
         let spec = start_err_worker("child1", "boom");
 
         let ctx = Context::new();
-        let result = spec.start(&ctx, "root").await;
-        match result {
-            Err(start_err1) => assert_eq!("boom", format!("{:?}", start_err1)),
-            Ok(_) => panic!("expecting error, got result"),
-        }
+        let start_err = spec
+            .start(&ctx, "root")
+            .await
+            .map(|_| ())
+            .map_err(|err| err.1)
+            .expect_err("worker start must fail");
+        assert!(start_err.is_worker_init_error());
     }
 
     #[tokio::test]
@@ -486,16 +565,13 @@ mod tests {
 
         time::advance(Duration::from_secs(4)).await;
 
-        let result = worker_fut.await;
+        let err = worker_fut
+            .await
+            .map(|_| ())
+            .map_err(|err| err.1)
+            .expect_err("worker start must fail");
 
-        match result {
-            Err(start_timeout_err) => {
-                // TODO: create well-defined capataz error that describes the error
-                // succintly
-                assert_eq!("deadline has elapsed", format!("{:?}", start_timeout_err))
-            }
-            Ok(_) => panic!("expecting error, got result"),
-        }
+        assert!(err.is_timeout_error());
     }
 
     #[tokio::test]
@@ -503,37 +579,31 @@ mod tests {
         let spec = no_start_worker("child1");
 
         let ctx = Context::new();
-        let result = spec.start(&ctx, "root").await;
-
-        match result {
-            Err(start_not_called_err) => {
-                // TODO: create well-defined capataz error that describes the error
-                // succintly
-                assert_eq!("channel closed", format!("{:?}", start_not_called_err))
-            }
-            Ok(_) => panic!("expecting error, got result"),
-        }
+        let err = spec
+            .start(&ctx, "root")
+            .await
+            .map(|_| ())
+            .map_err(|err| err.1)
+            .expect_err("worker start must fail");
+        assert!(err.is_notify_start_error());
     }
 
     #[tokio::test]
     async fn test_worker_termination_with_panic() {
         let spec = panic_worker("child1", "panic boom");
         let ctx = Context::new();
-        let worker = spec.start(&ctx, "root").await.expect("should match worker");
-
-        let (_, result) = worker.terminate().await;
-
-        match result {
-            Some(panic_err) => {
-                // TODO: create well-defined capataz error that describes the error
-                // succintly
-                assert_eq!(
-                    "PanicError(JoinError::Panic(...))",
-                    format!("{:?}", panic_err)
-                )
-            }
-            None => panic!("expecting error, got result"),
-        }
+        let worker = spec
+            .start(&ctx, "root")
+            .await
+            .map_err(|err| err.1)
+            .expect("worker start must succeed");
+        let err = worker
+            .terminate()
+            .await
+            .map(|_| ())
+            .map_err(|err| err.1)
+            .expect_err("worker termination must fail");
+        assert!(err.is_join_handle_error())
     }
 
     #[tokio::test]
@@ -544,11 +614,14 @@ mod tests {
         let worker = spec
             .start(&ctx, "root")
             .await
-            .expect("worker should be returned");
+            .map_err(|err| err.1)
+            .expect("worker must be spawned");
 
-        let (_, result) = worker.terminate().await;
-
-        assert!(result.is_none());
+        worker
+            .terminate()
+            .await
+            .map_err(|err| err.1)
+            .expect("worker must terminate");
     }
 
     #[tokio::test]
@@ -559,15 +632,16 @@ mod tests {
         let worker = spec
             .start(&ctx, "root")
             .await
-            .expect("worker should be returned");
+            .map_err(|err| err.1)
+            .expect("worker start must succeed");
 
-        let (_, result) = worker.terminate().await;
-
-        assert!(result.is_some());
-        assert_eq!(
-            "ClientError(termination_failed_worker)",
-            format!("{:?}", result.unwrap())
-        );
+        let err = worker
+            .terminate()
+            .await
+            .map(|_| ())
+            .map_err(|err| err.1)
+            .expect_err("worker termination must fail");
+        assert!(err.is_worker_termination_error());
     }
 
     #[tokio::test]
@@ -584,27 +658,18 @@ mod tests {
         let worker = spec
             .start(&ctx, "root")
             .await
-            .expect("should return worker");
+            .map_err(|err| err.1)
+            .expect("worker start must succeed");
 
         let termination_fut = worker.terminate();
 
         time::advance(Duration::from_secs(4)).await;
 
-        let (_, result) = termination_fut.await;
-
-        match result {
-            Some(termination_timeout_err) => {
-                // TODO: create well-defined capataz error that describes the error
-                // succintly
-                assert_eq!(
-                    "TimeoutError(Elapsed(()))",
-                    format!("{:?}", termination_timeout_err)
-                );
-                // NOTE: not sure how to validate the abort logic got executed,
-                // and what the side-effects of those are. @RadicalZephyr, if
-                // you have any ideas, I'm all ears.
-            }
-            None => panic!("expecting error, got none"),
-        }
+        let err = termination_fut
+            .await
+            .map(|_| ())
+            .map_err(|err| err.1)
+            .expect_err("worker termination must fail");
+        assert!(err.is_timeout_error());
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -516,6 +516,9 @@ mod tests {
         let ctx = Context::new();
         let worker = spec.start(&ctx, "root").await.expect("should match worker");
 
+        // QUESTION/TODO: I've some doubts here, what would happen if a future
+        // panics and we don't do an await on it? How can we verify worker futures
+        // are running with no panics without calling .await on them?
         let (_, result) = worker.terminate().await;
 
         match result {


### PR DESCRIPTION
## Problem

Currently, we don't have any tests that validate the termination logic of a worker is actually useful or valid

## Solution

Implement tests for the various aspects of worker termination

## Acceptance Criteria

* [x] tests for successful terminations
* [x] tests for failed terminations
* [x] tests for timed-out terminations

