### PR TITLE
Add wait_till functionality to EventBuffer

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,14 @@
-{pkgs ? import ./nix/packages.nix { nightly = false; }}:
+let
+  pinnedPkgs = import ./nix/packages.nix { nightly = false; };
+in
+
+{ pkgs ? pinnedPkgs }:
 
 pkgs.mkShell {
   buildInputs = with pkgs; [
     # general purpose deps
-    cacert
     figlet
-    stdenv
+    cacert
 
     # rust related deps
     crate2nix

--- a/src/events.rs
+++ b/src/events.rs
@@ -255,6 +255,31 @@ where
     }))
 }
 
+/// supervisor_terminated asserts an event that tells a supervisor with the given
+/// name was terminated
+pub fn supervisor_start_failed<S>(input_name0: S) -> EventAssert
+where
+    S: Into<String> + Clone,
+{
+    let input_name = input_name0.into();
+    EventAssert(Box::new(move |ev| match &ev {
+        Event::SupervisorStartFailed(NodeData { runtime_name }, _) => {
+            if runtime_name != &*input_name {
+                Some(format!(
+                    "Expecting SupervisorStartFailed with name {}; got {:?} instead",
+                    input_name, ev
+                ))
+            } else {
+                None
+            }
+        }
+        _ => Some(format!(
+            "Expecting SupervisorStartFailed; got {:?} instead",
+            ev
+        )),
+    }))
+}
+
 /// worker_started asserts an event that tells a worker with the given name
 /// started
 pub fn worker_started(input_name0: &str) -> EventAssert {

--- a/src/events.rs
+++ b/src/events.rs
@@ -180,7 +180,7 @@ impl EventBufferCollector {
         let events = self.get_events().await;
         assert_eq!(events.len(), asserts.len(), "{:?}", events);
         for (ev, assert) in events.into_iter().zip(asserts.into_iter()) {
-            assert.check(ev)
+            assert.check(&ev)
         }
     }
 
@@ -194,13 +194,13 @@ impl EventBufferCollector {
 
 /// EventAssert is a well-defined function that asserts properties from an Event
 /// emitted by a running supervision tree.
-pub struct EventAssert(Box<dyn Fn(Event) -> Option<String>>);
+pub struct EventAssert(Box<dyn Fn(&Event) -> Option<String>>);
 
 impl EventAssert {
-    fn call(&self, ev: Event) -> Option<String> {
+    fn call(&self, ev: &Event) -> Option<String> {
         (*self.0)(ev)
     }
-    pub fn check(&self, ev: Event) {
+    pub fn check(&self, ev: &Event) {
         let result = self.call(ev);
         if let Some(err_msg) = result {
             panic!("EventAssert failed: {}", err_msg);

--- a/src/events.rs
+++ b/src/events.rs
@@ -210,8 +210,11 @@ impl EventAssert {
 
 /// supervisor_started asserts an event that tells a supervisor with the given
 /// name started
-pub fn supervisor_started(input_name0: &str) -> EventAssert {
-    let input_name = input_name0.to_owned();
+pub fn supervisor_started<S>(input_name0: S) -> EventAssert
+where
+    S: Into<String>,
+{
+    let input_name = input_name0.into();
     EventAssert(Box::new(move |ev| match &ev {
         Event::SupervisorStarted(NodeData { runtime_name }) => {
             if runtime_name != &*input_name {
@@ -229,8 +232,11 @@ pub fn supervisor_started(input_name0: &str) -> EventAssert {
 
 /// supervisor_terminated asserts an event that tells a supervisor with the given
 /// name was terminated
-pub fn supervisor_terminated(input_name0: &str) -> EventAssert {
-    let input_name = input_name0.to_owned();
+pub fn supervisor_terminated<S>(input_name0: S) -> EventAssert
+where
+    S: Into<String> + Clone,
+{
+    let input_name = input_name0.into();
     EventAssert(Box::new(move |ev| match &ev {
         Event::SupervisorTerminated(NodeData { runtime_name }) => {
             if runtime_name != &*input_name {

--- a/src/events.rs
+++ b/src/events.rs
@@ -4,7 +4,7 @@ use std::time;
 use futures::future::{BoxFuture, Future, FutureExt};
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::task::{self, JoinHandle};
-use tokio::time::timeout;
+use tokio::time::{timeout_at, Instant};
 
 use crate::supervisor;
 use crate::worker;
@@ -218,7 +218,7 @@ impl EventBufferCollector {
 
             // we finished the loop, we have to wait until the next push and try
             // again. if we wait too long, fail with a timeout error
-            if let Err(_) = timeout(wait_duration, self.on_push.recv()).await {
+            if let Err(_) = timeout_at(Instant::now() + wait_duration, self.on_push.recv()).await {
                 return Err("Expected assertion after timeout, did not happen".to_owned());
             }
         }

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -330,93 +330,73 @@ impl Supervisor {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
     use tokio::time;
 
     use crate::context::*;
     use crate::events::{
-        supervisor_started, testing_event_notifier, worker_start_failed, worker_started,
-        worker_terminated, worker_termination_failed,
+        supervisor_start_failed, supervisor_started, supervisor_terminated, testing_event_notifier,
+        worker_start_failed, worker_started, worker_terminated, worker_termination_failed,
+        EventAssert,
     };
     use crate::supervisor;
+    use crate::worker;
     use crate::worker::tests::{
         start_err_worker, start_timeout_worker, termination_failed_worker, wait_done_worker,
     };
 
-    #[tokio::test]
-    async fn test_simple_start_and_stop_with_one_child() {
-        let (event_notifier, event_buffer) = testing_event_notifier().await;
-        let spec = supervisor::Spec::new("root", vec![wait_done_worker("one")], event_notifier);
-
+    // start_stop_supervisor is a helper function that creates a supervisor and
+    // then asserts it started successfuly; after that assertion, it executes
+    // its termination and asserts that termination was done successfully. This
+    // helper function expects workers that do not fail on start or termination
+    // (wait_done_worker).
+    async fn start_stop_supervisor(
+        root_name: &str,
+        children: Vec<worker::Spec>,
+        assertions: Vec<EventAssert>,
+    ) {
+        let (event_notifier, mut event_buffer) = testing_event_notifier().await;
+        let spec = supervisor::Spec::new(root_name, children, event_notifier);
         let ctx = Context::new();
-
         let start_result = spec.start(&ctx).await;
         let sup = start_result
             .map_err(|err| err.1)
             .expect("successful supervisor start");
+
+        event_buffer
+            .wait_till(
+                supervisor_started(format!("/{}", root_name)),
+                Duration::from_millis(100),
+            )
+            .await
+            .expect("supervisor started timeout");
 
         let (_, terminate_result) = sup.terminate().await;
         let _ = terminate_result.expect("successful supervisor termination");
 
         event_buffer
-            .assert_exact(vec![
-                worker_started("/root/one"),
-                supervisor_started("/root"),
-                worker_terminated("/root/one"),
-            ])
-            .await;
+            .wait_till(
+                supervisor_terminated(format!("/{}", root_name)),
+                Duration::from_millis(10),
+            )
+            .await
+            .expect("supervisor termination timeout");
+
+        event_buffer.assert_exact(assertions).await;
     }
 
-    #[tokio::test]
-    async fn test_simple_start_and_stop_with_multiple_children() {
-        let (event_notifier, event_buffer) = testing_event_notifier().await;
-        let spec = supervisor::Spec::new(
-            "root",
-            vec![
-                wait_done_worker("one"),
-                wait_done_worker("two"),
-                wait_done_worker("three"),
-            ],
-            event_notifier,
-        );
-
-        let ctx = Context::new();
-
-        let start_result = spec.start(&ctx).await;
-        let sup = start_result
-            .map_err(|err| err.1)
-            .expect("successful supervisor start");
-
-        let (_spec, terminate_result) = sup.terminate().await;
-        terminate_result.expect("successful supervisor termination");
-
-        event_buffer
-            .assert_exact(vec![
-                worker_started("/root/one"),
-                worker_started("/root/two"),
-                worker_started("/root/three"),
-                supervisor_started("/root"),
-                worker_terminated("/root/three"),
-                worker_terminated("/root/two"),
-                worker_terminated("/root/one"),
-            ])
-            .await;
-    }
-
-    #[tokio::test]
-    async fn test_failing_start_with_multiple_children() {
-        let (event_notifier, event_buffer) = testing_event_notifier().await;
-        let spec = supervisor::Spec::new(
-            "root",
-            vec![
-                wait_done_worker("one"),
-                start_err_worker("two", "boom"),
-                wait_done_worker("three"),
-            ],
-            event_notifier,
-        );
-
+    // err_start_supervisor is a helper function that creates a supervisor and
+    // then asserts that it fails at start. This helper function expects workers
+    // that fail on start (start_err_worker).
+    async fn err_start_supervisor(
+        root_name: &str,
+        children: Vec<worker::Spec>,
+        assertions: Vec<EventAssert>,
+    ) {
+        let (event_notifier, mut event_buffer) = testing_event_notifier().await;
+        let spec = supervisor::Spec::new(root_name, children, event_notifier);
         let ctx = Context::new();
 
         let start_result = spec.start(&ctx).await;
@@ -428,104 +408,171 @@ mod tests {
         assert!(start_err.failing_child_error.is_worker_init_error());
 
         event_buffer
-            .assert_exact(vec![
+            .wait_till(
+                supervisor_start_failed(format!("/{}", root_name)),
+                Duration::from_millis(10),
+            )
+            .await
+            .expect("expected supervisor starte failure event timed out");
+
+        event_buffer.assert_exact(assertions).await;
+    }
+
+    // start_timeout_supervisor is a helper function that creates a supervisor
+    // and then asserts that it fails with a timeout at start. This helper
+    // function expects workers that fail on the start (start_timeout_worker).
+    // The first parameter is a delay to forward to the virtual clock to kick
+    // timeouts.
+    async fn start_timeout_supervisor(
+        start_delay: time::Duration,
+        root_name: &str,
+        children: Vec<worker::Spec>,
+        assertions: Vec<EventAssert>,
+    ) -> Arc<supervisor::StartError> {
+        let (event_notifier, mut event_buffer) = testing_event_notifier().await;
+        let spec = supervisor::Spec::new(root_name, children, event_notifier);
+
+        let ctx = Context::new();
+
+        time::pause();
+
+        let start_fut = spec.start(&ctx);
+
+        time::advance(start_delay).await;
+
+        let start_result = start_fut.await;
+        let start_err = start_result
+            .map(|_| ())
+            .map_err(|err| err.1)
+            .expect_err("supervisor start must fail");
+
+        assert!(start_err.failing_child_error.is_timeout_error());
+
+        event_buffer
+            .wait_till(
+                supervisor_start_failed(format!("/{}", root_name)),
+                Duration::from_millis(10),
+            )
+            .await
+            .expect("expected supervisor started failure event timed out");
+
+        event_buffer.assert_exact(assertions).await;
+        return start_err;
+    }
+
+    #[tokio::test]
+    async fn test_simple_start_and_stop_with_one_child() {
+        start_stop_supervisor(
+            "root",
+            vec![wait_done_worker("one")],
+            vec![
+                worker_started("/root/one"),
+                supervisor_started("/root"),
+                worker_terminated("/root/one"),
+                supervisor_terminated("/root"),
+            ],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_simple_start_and_stop_with_multiple_children() {
+        start_stop_supervisor(
+            "root",
+            vec![
+                wait_done_worker("one"),
+                wait_done_worker("two"),
+                wait_done_worker("three"),
+            ],
+            vec![
+                worker_started("/root/one"),
+                worker_started("/root/two"),
+                worker_started("/root/three"),
+                supervisor_started("/root"),
+                worker_terminated("/root/three"),
+                worker_terminated("/root/two"),
+                worker_terminated("/root/one"),
+                supervisor_terminated("/root"),
+            ],
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_failing_start_with_multiple_children() {
+        err_start_supervisor(
+            "root",
+            vec![
+                wait_done_worker("one"),
+                start_err_worker("two", "boom"),
+                wait_done_worker("three"),
+            ],
+            vec![
                 worker_started("/root/one"),
                 worker_start_failed("/root/two"),
                 worker_terminated("/root/one"),
-                // supervisor_start_failed("/root"),
-            ])
-            .await;
+                supervisor_start_failed("/root"),
+            ],
+        )
+        .await
     }
 
     #[tokio::test]
     async fn test_timeout_start_with_multiple_children() {
-        let (event_notifier, event_buffer) = testing_event_notifier().await;
-        let spec = supervisor::Spec::new(
+        let worker_max_start_delay = Duration::from_secs(1);
+        let worker_start_delay = Duration::from_secs(3);
+        let _ = start_timeout_supervisor(
+            worker_start_delay,
             "root",
             vec![
                 wait_done_worker("one"),
                 wait_done_worker("two"),
                 start_timeout_worker(
                     "three",
-                    Duration::from_secs(1), // timeout
-                    Duration::from_secs(3), // delay
+                    worker_max_start_delay, // timeout
+                    worker_start_delay,     // delay
                 ),
             ],
-            event_notifier,
-        );
-
-        let ctx = Context::new();
-
-        time::pause();
-
-        let start_fut = spec.start(&ctx);
-
-        time::advance(Duration::from_secs(4)).await;
-
-        let start_result = start_fut.await;
-        let start_err = start_result
-            .map(|_| ())
-            .map_err(|err| err.1)
-            .expect_err("supervisor start must fail");
-
-        assert!(start_err.failing_child_error.is_timeout_error());
-
-        event_buffer
-            .assert_exact(vec![
+            vec![
                 worker_started("/root/one"),
                 worker_started("/root/two"),
                 worker_start_failed("/root/three"),
                 worker_terminated("/root/two"),
                 worker_terminated("/root/one"),
-                // supervisor_start_failed("/root"),
-            ])
-            .await;
+                supervisor_start_failed("/root"),
+            ],
+        )
+        .await;
     }
 
     #[tokio::test]
     async fn test_start_timeout_and_termination_timeout_with_multiple_children() {
-        let (event_notifier, event_buffer) = testing_event_notifier().await;
-        let spec = supervisor::Spec::new(
+        let worker_max_start_delay = Duration::from_secs(1);
+        let worker_start_delay = Duration::from_secs(3);
+
+        let start_err = start_timeout_supervisor(
+            worker_start_delay,
             "root",
             vec![
                 wait_done_worker("one"),
                 termination_failed_worker("two"),
                 start_timeout_worker(
                     "three",
-                    Duration::from_secs(1), // timeout
-                    Duration::from_secs(3), // delay
+                    worker_max_start_delay, // declared timeout
+                    worker_start_delay,
                 ),
             ],
-            event_notifier,
-        );
-
-        let ctx = Context::new();
-
-        time::pause();
-
-        let start_fut = spec.start(&ctx);
-
-        time::advance(Duration::from_secs(4)).await;
-
-        let start_result = start_fut.await;
-        let start_err = start_result
-            .map(|_| ())
-            .map_err(|err| err.1)
-            .expect_err("supervisor start must fail");
-
-        event_buffer
-            .assert_exact(vec![
+            vec![
                 worker_started("/root/one"),
                 worker_started("/root/two"),
                 worker_start_failed("/root/three"),
                 worker_termination_failed("/root/two"),
                 worker_terminated("/root/one"),
-                // supervisor_start_failed("/root"),
-            ])
-            .await;
+                supervisor_start_failed("/root"),
+            ],
+        )
+        .await;
 
-        // there is a timeout error
-        assert!(start_err.failing_child_error.is_timeout_error());
         // there is an entry in the termination error
         let mtermination_err = start_err.failing_sibling_termination_error.as_ref();
         match mtermination_err {


### PR DESCRIPTION
## Problem

In order to assert restarts on the API, we need to make sure certain events happen in the supervision system (wait for them via sync mechanism) before failing.

## Solutions

The `wait_till` method on the `EventBuffer` allows us to block for a particular event, this way, we can make sure that when we fail a worker on a test, we know we are in the right state in the Supervisor to run the test.

## Acceptance Criteria

* [x] The `wait_till` method is implemented on the `EventBuffer` type
* [x] The `wait_till` method is used in the existing Supervisor tests