### PR TITLE
Add monitor loop to supervisor logic

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -401,7 +401,7 @@ async fn run_event_collector(
 ) {
     while let Some(ev) = receiver.recv().await {
         // IMPORTANT: DO NOT REMOVE DEBUG LINE COMMENT BELLOW
-        println!("{:?}", ev);
+        // println!("{:?}", ev);
 
         let mut ev_vec = events.lock().await;
         ev_vec.push(ev);

--- a/src/events.rs
+++ b/src/events.rs
@@ -31,7 +31,7 @@ pub struct NodeData {
 
 /// NotifyFn is used by the supervision API to send events to an interested
 /// listener.
-type NotifyFn = Box<dyn Fn(Event) -> BoxFuture<'static, ()>>;
+type NotifyFn = Box<dyn (Fn(Event) -> BoxFuture<'static, ()>) + Send + Sync>;
 
 /// EventNotifier is used by the internal supervision API to send events about a
 /// running supervision tree
@@ -41,7 +41,7 @@ pub struct EventNotifier(Arc<NotifyFn>);
 impl EventNotifier {
     pub fn new<F, O>(notify0: F) -> Self
     where
-        F: Fn(Event) -> O + 'static,
+        F: (Fn(Event) -> O) + Send + Sync + 'static,
         O: Future<Output = ()> + FutureExt + Send + 'static,
     {
         let notify = move |ev| {
@@ -219,7 +219,9 @@ impl EventBufferCollector {
             // we finished the loop, we have to wait until the next push and try
             // again. if we wait too long, fail with a timeout error
             if let Err(_) = timeout_at(Instant::now() + wait_duration, self.on_push.recv()).await {
-                return Err("Expected assertion after timeout, did not happen".to_owned());
+                return Err(
+                    "wait_till: Expected assertion after timeout, did not happen".to_owned(),
+                );
             }
         }
     }
@@ -398,6 +400,9 @@ async fn run_event_collector(
     mut receiver: mpsc::Receiver<Event>,
 ) {
     while let Some(ev) = receiver.recv().await {
+        // IMPORTANT: DO NOT REMOVE DEBUG LINE COMMENT BELLOW
+        println!("{:?}", ev);
+
         let mut ev_vec = events.lock().await;
         ev_vec.push(ev);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate lazy_static;
 #[allow(clippy::new_without_default)]
 mod context;
 mod events;
+mod notifier;
 mod supervisor;
 mod worker;
 

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -11,7 +11,7 @@ impl<T, E> StartNotifier<T, E> {
         E: Send + 'static,
     {
         StartNotifier(Box::new(move |err| {
-            let _ = sender.send(err);
+            sender.send(err).ok();
         }))
     }
 

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -1,16 +1,16 @@
 use tokio::sync::oneshot;
 
-/// SpawnedNotifier offers a convenient way to notify a supervising task that this
+/// StartNotifier offers a convenient way to notify a supervising task that this
 /// task got started or that it failed to start.
-pub struct SpawnedNotifier<T, E>(Box<dyn FnOnce(Result<T, E>) + Send>);
+pub struct StartNotifier<T, E>(Box<dyn FnOnce(Result<T, E>) + Send>);
 
-impl<T, E> SpawnedNotifier<T, E> {
+impl<T, E> StartNotifier<T, E> {
     pub fn from_oneshot(sender: oneshot::Sender<Result<T, E>>) -> Self
     where
         T: Send + 'static,
         E: Send + 'static,
     {
-        SpawnedNotifier(Box::new(move |err| {
+        StartNotifier(Box::new(move |err| {
             let _ = sender.send(err);
         }))
     }

--- a/src/notifier.rs
+++ b/src/notifier.rs
@@ -1,0 +1,29 @@
+use tokio::sync::oneshot;
+
+/// SpawnedNotifier offers a convenient way to notify a supervising task that this
+/// task got started or that it failed to start.
+pub struct SpawnedNotifier<T, E>(Box<dyn FnOnce(Result<T, E>) + Send>);
+
+impl<T, E> SpawnedNotifier<T, E> {
+    pub fn from_oneshot(sender: oneshot::Sender<Result<T, E>>) -> Self
+    where
+        T: Send + 'static,
+        E: Send + 'static,
+    {
+        SpawnedNotifier(Box::new(move |err| {
+            let _ = sender.send(err);
+        }))
+    }
+
+    fn call(self, err: Result<T, E>) {
+        self.0(err)
+    }
+
+    pub fn success(self, result: T) {
+        self.call(Ok(result))
+    }
+
+    pub fn failed(self, err: E) {
+        self.call(Err(err))
+    }
+}

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -389,11 +389,11 @@ async fn run_supervisor_monitor(
 
 impl Spec {
     pub fn new(
-        name0: impl Into<String>,
+        name: impl Into<String>,
         children: Vec<worker::Spec>,
         ev_notifier: EventNotifier,
     ) -> Spec {
-        let name = name0.into();
+        let name = name.into();
         Spec {
             meta: SpecMeta {
                 ev_notifier,
@@ -479,7 +479,7 @@ impl Spec {
         // We wait for the supervisor to get started, and from there we return a
         // Supervisor record to the client, which can terminate the supervisor,
         // or wait for it to finish
-        return match started_recv.await {
+        match started_recv.await {
             // there is no way the monitor loop is going to drop the start
             // notifier before exiting, if we reach this branch, is an
             // implementation error
@@ -494,7 +494,7 @@ impl Spec {
                     termination_handle,
                 })
             }
-        };
+        }
     }
 }
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -288,7 +288,7 @@ async fn terminate_supervisor_monitor(
 ///
 /// ### Calling this function on new spawned thread (`start_notifier` given)
 ///
-/// When this function gets executed on a spawned task, is because we are the
+/// When this function gets executed on a spawned task, it is because we are the
 /// root supervisor. In this scenario, we want to signal the supervisor that we
 /// got started without having to `.await` on the join_handle result from the
 /// spawned task.

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -71,11 +71,6 @@ pub struct Spec {
     pub meta: SpecMeta,
 }
 
-// type SupervisorResult = Result<
-//     (Spec, Result<(), Arc<TerminationError>>), /* result when supervisor starts without errors */
-//     Option<(Spec, Arc<StartError>)>,           /* result when the supervisor fails to start */
-// >;
-
 /// A value that gets returned when running a Supervisor record
 enum SupervisorResult {
     // gets returned when the supervisor failed to start

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -543,11 +543,14 @@ impl Supervisor {
                 eprintln!("{:?}", join_handle_err);
                 panic!("supervisor monitor loop had a join_handle error; invalid implementation")
             }
+
             // ErrStart means we got an start error, this has been dealt
             // with, and so it must never happen
             Ok(SupervisorResult::ErrStartHandled) => unreachable!(),
             Ok(SupervisorResult::ErrStart { .. }) => unreachable!(),
 
+            // we perform a transformation to more generic types so that clients don't
+            // get coupled with out enums
             Ok(SupervisorResult::OkTermination { spec }) => (spec, Ok(())),
             Ok(SupervisorResult::ErrTermination { spec, err }) => (spec, Err(err)),
         }

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -405,6 +405,23 @@ impl Spec {
         }
     }
 
+    /// run executes the supervisor monitoring logic on the existing task. This function:
+    ///
+    /// 1. spawns a new routine for the supervision loop
+    ///
+    /// 2. spawns each node routine in the correct order
+    ///
+    /// 3. stops all the spawned nodes in the correct order once it gets a
+    /// stop signal
+    ///
+    /// 4. it monitors and reacts to errors reported by the supervised nodes
+    ///
+    async fn run(self, parent_ctx: context::Context, parent_name: &str) -> SupervisorResult {
+        let Spec { meta, children } = self;
+        let sup_runtime_name = format!("{}/{}", parent_name, meta.name);
+        run_supervisor_monitor(parent_ctx.clone(), meta, children, None, sup_runtime_name).await
+    }
+
     /// start is future that contains the main logic of a Supervisor. This
     /// function:
     ///

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -11,7 +11,7 @@ use tokio::task::{self, JoinHandle};
 
 use crate::context::{self, Context};
 use crate::events::EventNotifier;
-use crate::notifier::SpawnedNotifier;
+use crate::notifier::StartNotifier;
 use crate::worker::{self, Worker};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -297,7 +297,7 @@ async fn run_supervisor_monitor(
     parent_ctx: context::Context,
     meta: SpecMeta,
     children_spec: Vec<worker::Spec>,
-    mstart_notifier: Option<SpawnedNotifier<(), (Spec, Arc<StartError>)>>,
+    mstart_notifier: Option<StartNotifier<(), (Spec, Arc<StartError>)>>,
     sup_runtime_name: String,
 ) -> SupervisorResult {
     let (ctx, _terminate_supervisor) = Context::with_cancel(&parent_ctx);
@@ -460,7 +460,7 @@ impl Spec {
 
         // started is used when waiting for the worker to signal it has started
         let (started_send, started_recv) = oneshot::channel();
-        let start_notifier = SpawnedNotifier::from_oneshot(started_send);
+        let start_notifier = StartNotifier::from_oneshot(started_send);
 
         let spec_children = self.children;
 

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -103,7 +103,7 @@ pub struct Supervisor {
 
 // terminate_prev_siblings gets called when a child in a supervision tree fails
 // to start, and all it's previous siblings need to get terminated.
-async fn terminate_prev_siblings<I: DoubleEndedIterator<Item = worker::Spec> + Send>(
+async fn terminate_prev_siblings<I: DoubleEndedIterator<Item = worker::Spec>>(
     ev_notifier: &mut EventNotifier,
     order: Order,
     failed_child_spec: worker::Spec,

--- a/src/supervisor/mod.rs
+++ b/src/supervisor/mod.rs
@@ -263,7 +263,7 @@ async fn terminate_supervisor_monitor(
     };
 
     match err {
-        Ok(_) => {
+        Ok(()) => {
             ev_notifier.supervisor_terminated(sup_runtime_name).await;
             return (spec, Ok(()));
         }

--- a/src/supervisor/subtree.rs
+++ b/src/supervisor/subtree.rs
@@ -1,0 +1,23 @@
+use futures::future::{abortable, AbortHandle, Aborted, BoxFuture, Future, FutureExt};
+use std::time::Duration;
+
+use crate::supervisor::{Context, Spec, Supervisor};
+use crate::worker::{self, StartNotifier};
+
+impl Supervisor {
+    pub fn subtree(&mut self, sup_spec: Spec) -> (worker::Spec, oneshot::Receiver<Spec>) {
+        let parent_name: String = self.data.name.clone();
+        worker::Spec::new_with_start(
+            &self.data.name,
+            move |parent_ctx: Context, start_notifier: StartNotifier| async move {
+                let (ctx, cancel) = parent_ctx.with_cancel();
+                sup_spec
+                    .run_supervisor(&ctx, &parent_name, start_notifier)
+                    .await
+            },
+        )
+        .shutdown(worker::Shutdown::Indefinitely)
+        .tolerance(1, Duration::from_secs(5))
+        .tag(worker::Tag::Supervisor)
+    }
+}

--- a/src/supervisor/tests.rs
+++ b/src/supervisor/tests.rs
@@ -29,7 +29,7 @@ async fn start_stop_supervisor(
     let ctx = Context::new();
     let start_result = spec.start(&ctx).await;
     let sup = start_result
-        .map_err(|err| err.1)
+        .map_err(|err| err.1.clone())
         .expect("successful supervisor start");
 
     event_buffer
@@ -69,7 +69,7 @@ async fn err_start_supervisor(
     let start_result = spec.start(&ctx).await;
     let start_err = start_result
         .map(|_| ())
-        .map_err(|err| err.1)
+        .map_err(|err| err.1.clone())
         .expect_err("supervisor start must fail");
 
     assert!(start_err.failing_child_error.is_worker_init_error());
@@ -110,7 +110,7 @@ async fn start_timeout_supervisor(
     let start_result = start_fut.await;
     let start_err = start_result
         .map(|_| ())
-        .map_err(|err| err.1)
+        .map_err(|err| err.1.clone())
         .expect_err("supervisor start must fail");
 
     assert!(start_err.failing_child_error.is_timeout_error());

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -162,9 +162,7 @@ pub struct Spec {
     restart: Restart,
     shutdown: Shutdown,
     routine: Box<
-        dyn (FnMut(Context, StartNotifier) -> BoxFuture<'static, Result<(), anyhow::Error>>)
-            + Send
-            + Sync,
+        dyn (FnMut(Context, StartNotifier) -> BoxFuture<'static, Result<(), anyhow::Error>>) + Send,
     >,
 }
 
@@ -202,7 +200,7 @@ impl Spec {
     ///
     pub fn new<F, O>(name: &str, mut routine0: F) -> Self
     where
-        F: (FnMut(Context) -> O) + Send + Sync + 'static,
+        F: (FnMut(Context) -> O) + Send + 'static,
         O: Future<Output = anyhow::Result<()>> + FutureExt + Send + Sized + 'static,
     {
         let routine1 = move |ctx: Context, on_start: StartNotifier| {
@@ -243,7 +241,7 @@ impl Spec {
     ///
     pub fn new_with_start<F, O>(name: &str, mut routine0: F) -> Self
     where
-        F: (FnMut(Context, StartNotifier) -> O) + Send + Sync + 'static,
+        F: (FnMut(Context, StartNotifier) -> O) + Send + 'static,
         O: Future<Output = anyhow::Result<()>> + FutureExt + Send + Sized + 'static,
     {
         let routine1 = move |ctx: Context, on_start: StartNotifier| routine0(ctx, on_start).boxed();

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -135,13 +135,13 @@ impl StartError {
 /// StartNotifier offers a convenient way to notify a worker spawner (a
 /// Supervisor in the general case) that the worker got started or that it
 /// failed to start.
-pub struct StartNotifier(notifier::SpawnedNotifier<(), StartError>);
+pub struct StartNotifier(notifier::StartNotifier<(), StartError>);
 
 // We wrap the internal SpawnNotifier to offer a better API experience on the
 // Worker declration for API clients
 impl StartNotifier {
     fn from_oneshot(sender: oneshot::Sender<Result<(), StartError>>) -> Self {
-        let notifier = notifier::SpawnedNotifier::from_oneshot(sender);
+        let notifier = notifier::StartNotifier::from_oneshot(sender);
         StartNotifier(notifier)
     }
 


### PR DESCRIPTION
### Context

This pull request modifies the supervisor logic in a way that:

* It runs on a new task when `start` is called
* It supports running on a new task or in the same thread (`run` method)
* It keeps the start and termination ordering guarantees that were implemented before